### PR TITLE
Fixed potential test failure due to nondeterminism in the order of elements in jsonString in SimpleFilterProviderTest.testAddFilterLastOneRemainsFlip test

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.ser.FilterProvider;
 import com.fasterxml.jackson.databind.ser.impl.SimpleBeanPropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
-
+import java.util.Map;
 /**
  * Tests {@link SimpleFilterProvider} on registration of filters.
  */
@@ -72,7 +72,10 @@ public class SimpleFilterProviderTest extends BaseMapTest
 
         String jsonString = MAPPER.writer(prov).writeValueAsString(beanB);
 
-        assertEquals(a2q("{'a':'1a','b':'2b'}"), jsonString);
+        Map<String, Object> expectedMap = Map.of("a", "1a", "b", "2b");
+        Map<String, Object> actualMap = MAPPER.readValue(jsonString, Map.class);
+
+        assertEquals(expectedMap, actualMap);
     }
 
     public void testAddFilterWithEmptyStringId() throws Exception {


### PR DESCRIPTION
This pull request addresses the flakiness in the `SimpleFilterProviderTest.testAddFilterLastOneRemainsFlip` test by resolving the non-deterministic behavior identified using the NonDex tool. The root cause of the flakiness was the non-deterministic order of elements in the generated JSON string. The test can be found [here](https://github.com/FasterXML/jackson-databind/blob/2.17/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java).

- How was the non-deterministic behavior identified in the test?
The non-deterministic behavior in the test was identified by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

- Why does the test fail?
When `jsonString` is created using the bean object, the order of elements in the `jsonString` is not deterministic. The test assumes that the `jsonString` will be `{"[a":"1a","b":"2b]"}`. However, the order of elements in the `jsonString` is shuffled sometimes, due to which it is `{"[b":"2b","a":"1a]"}` sometimes instead of `{"[a":"1a","b":"2b]"}`. Due to this, the test fails some times.

- How I fixed the test?
I fixed the test by creating map objects from the two json strings that were being compared. Then, I compared the map objects in the assertion. This ensures that the two jsons are equivalent, irrespective of the order of elements within them.

You can run the following command to run the test using the NonDex tool:

```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.fasterxml.jackson.databind.ser.filter.SimpleFilterProviderTest#testAddFilterLastOneRemainsFlip
```

<br>
Test Environment:

```
java version 11.0.20.1
Apache Maven 3.6.3
```

Let me know if this fix is acceptable

Thank you!