### PR TITLE
Fixed com.fasterxml.jackson.databind.ser.filter.SimpleFilterProviderTest.testAddFilterWithEmptyStringId

### DIFF
--- a/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java
+++ b/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java
@@ -87,7 +87,12 @@ public class SimpleFilterProviderTest extends BaseMapTest
 
         String jsonString = MAPPER.writer(prov).writeValueAsString(bean);
 
-        assertEquals(a2q("{'c':null,'d':'D is filtered'}"), jsonString);
+        Map<String, Object> actualMap = MAPPER.readValue(jsonString, Map.class);
+        Map<String, Object> expectedMap = new LinkedHashMap<>();
+        expectedMap.put("c", null);
+        expectedMap.put("d", "D is filtered");
+        
+        assertEquals(expectedMap, actualMap);
     }
 
     public void testAddingNullFilter2ThrowsException() throws Exception {


### PR DESCRIPTION
This pull request addresses the flakiness in the `SimpleFilterProviderTest.testAddFilterWithEmptyStringId` test by resolving the non-deterministic behavior identified using the NonDex tool. The root cause of the flakiness was the non-deterministic order of elements in the generated JSON string. The test can be found [here](https://github.com/FasterXML/jackson-databind/blob/2.17/src/test/java/com/fasterxml/jackson/databind/ser/filter/SimpleFilterProviderTest.java).

- How was the non-deterministic behavior identified in the test?
The non-deterministic behavior in the test was identified by using an open-source research tool named [NonDex](https://github.com/TestingResearchIllinois/NonDex) which is responsible for finding and diagnosing non-deterministic runtime exceptions in Java programs.

- Why does the test fail?
When `jsonString` is created using the bean object, the order of elements in the `jsonString` is not deterministic. The test assumes that the `jsonString` will be `{"[c":null,"d":"D is filtered"]}`. However, the order of elements in the `jsonString` is shuffled sometimes, due to which it is `{"[d":"D is filtered","c":null]}` sometimes instead of `{"[c":null,"d":"D is filtered"]}`. Due to this, the test fails some times.

- How I fixed the test?
I fixed the test by creating map objects from the two json strings that were being compared. Then, I compared the map objects in the assertion. This ensures that the two jsons are equivalent, irrespective of the order of elements within them.

- Output from NonDex:
```
[INFO] Running com.fasterxml.jackson.databind.ser.filter.SimpleFilterProviderTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.069 s <<< FAILURE! -- in com.fasterxml.jackson.databind.ser.filter.SimpleFilterProviderTest
[ERROR] com.fasterxml.jackson.databind.ser.filter.SimpleFilterProviderTest.testAddFilterWithEmptyStringId -- Time elapsed: 0.050 s <<< FAILURE!
junit.framework.ComparisonFailure: expected:<{"[c":null,"d":"D is filtered"]}> but was:<{"[d":"D is filtered","c":null]}>
	at junit.framework.Assert.assertEquals(Assert.java:100)
	at junit.framework.Assert.assertEquals(Assert.java:107)
	at junit.framework.TestCase.assertEquals(TestCase.java:260)
	at com.fasterxml.jackson.databind.ser.filter.SimpleFilterProviderTest.testAddFilterWithEmptyStringId(SimpleFilterProviderTest.java:90)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at junit.framework.TestCase.runTest(TestCase.java:177)
	at junit.framework.TestCase.runBare(TestCase.java:142)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:130)
	at junit.framework.TestSuite.runTest(TestSuite.java:241)
	at junit.framework.TestSuite.run(TestSuite.java:236)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:90)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:115)
	at org.junit.vintage.engine.execution.RunnerExecutor.execute(RunnerExecutor.java:42)
	at org.junit.vintage.engine.VintageTestEngine.executeAllChildren(VintageTestEngine.java:80)
	at org.junit.vintage.engine.VintageTestEngine.execute(VintageTestEngine.java:72)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:147)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:127)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:90)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:55)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:102)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.apache.maven.surefire.junitplatform.LazyLauncher.execute(LazyLauncher.java:56)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.execute(JUnitPlatformProvider.java:184)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:148)
	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:122)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:385)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:507)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:495)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   SimpleFilterProviderTest.testAddFilterWithEmptyStringId:90 expected:<{"[c":null,"d":"D is filtered"]}> but was:<{"[d":"D is filtered","c":null]}>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
INFO: Surefire failed when running tests for PvJ029+vxNUyI+4OJE8WHHRpj1x8h2aVEfy4ZqB2Rg=
INFO: Adding excluded groups to newly created one
INFO: Adding NonDex argLine to existing argLine specified by the project
CONFIG: nondexFilter=.*
nondexMode=FULL
nondexSeed=974622
nondexStart=0
nondexEnd=9223372036854775807
nondexPrintstack=false
nondexDir=/home/shetty5/project/fixes/jackson-databind-simplefilterprovidertest/jackson-databind/.nondex
nondexJarDir=/home/shetty5/project/fixes/jackson-databind-simplefilterprovidertest/jackson-databind/.nondex
nondexExecid=fuITRdrplJbFDl+RcBEdHp2i3WJhWjFUVln9k7jM894=
nondexLogging=CONFIG
```

You can run the following command to run the test using the NonDex tool:

```
mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.fasterxml.jackson.databind.ser.filter.SimpleFilterProviderTest#testAddFilterWithEmptyStringId
```

<br>
Test Environment:

```
java version 11.0.20.1
Apache Maven 3.6.3
```

Let me know if this fix is acceptable

Thank you!